### PR TITLE
Use the fuzzer to verify correctness

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,3 +25,11 @@ path = "fuzz_targets/verify_u64.rs"
 [[bin]]
 name = "verify_i64"
 path = "fuzz_targets/verify_i64.rs"
+
+[[bin]]
+name = "verify_u128"
+path = "fuzz_targets/verify_u128.rs"
+
+[[bin]]
+name = "verify_i128"
+path = "fuzz_targets/verify_i128.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,3 +17,7 @@ members = ["."] # Let fuzzing suite not interfere with workspaces
 [[bin]]
 name = "btoi_radix"
 path = "fuzz_targets/btoi_radix.rs"
+
+[[bin]]
+name = "verify_u64"
+path = "fuzz_targets/verify_u64.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -21,3 +21,7 @@ path = "fuzz_targets/btoi_radix.rs"
 [[bin]]
 name = "verify_u64"
 path = "fuzz_targets/verify_u64.rs"
+
+[[bin]]
+name = "verify_i64"
+path = "fuzz_targets/verify_i64.rs"

--- a/fuzz/fuzz_targets/verify_i128.rs
+++ b/fuzz/fuzz_targets/verify_i128.rs
@@ -1,0 +1,26 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // choose a random radix
+    if data.len() == 0 {
+        return;
+    }
+    let radix: u32 = data[0].into();
+    let data = &data[1..];
+    if radix < 2 || radix > 36 {
+        return;
+    }
+    // parse the input
+    let result = btoi::btoi_radix::<i128>(data, radix);
+    // compare the resut to the stdlib implementation
+    if let Ok(string) = std::str::from_utf8(data) {
+        let std_result = i128::from_str_radix(string, radix);
+        match (result, std_result) {
+            (Ok(ours), Ok(std)) => assert_eq!(ours, std),
+            (Err(_), Err(_)) => (), // both failed, nothing to do
+            (ours, std) => panic!("Parsing result mismatch! Ours: {ours:?}, std: {std:?}"),
+        }
+    }
+});

--- a/fuzz/fuzz_targets/verify_i64.rs
+++ b/fuzz/fuzz_targets/verify_i64.rs
@@ -1,0 +1,27 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::str::FromStr;
+
+fuzz_target!(|data: &[u8]| {
+    // choose a random radix
+    if data.len() == 0 {
+        return;
+    }
+    let radix: u32 = data[0].into();
+    let data = &data[1..];
+    if radix < 2 || radix > 36 {
+        return;
+    }
+    // parse the input
+    let result = btoi::btoi_radix::<i64>(data, radix);
+    // compare the resut to the stdlib implementation
+    if let Ok(string) = std::str::from_utf8(data) {
+        let std_result = i64::from_str_radix(string, radix);
+        match (result, std_result) {
+            (Ok(ours), Ok(std)) => assert_eq!(ours, std),
+            (Err(_), Err(_)) => (), // both failed, nothing to do
+            (ours, std) => panic!("Parsing result mismatch! Ours: {ours:?}, std: {std:?}"),
+        }
+    }
+});

--- a/fuzz/fuzz_targets/verify_i64.rs
+++ b/fuzz/fuzz_targets/verify_i64.rs
@@ -1,7 +1,6 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use std::str::FromStr;
 
 fuzz_target!(|data: &[u8]| {
     // choose a random radix

--- a/fuzz/fuzz_targets/verify_u128.rs
+++ b/fuzz/fuzz_targets/verify_u128.rs
@@ -1,0 +1,30 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // choose a random radix
+    if data.len() == 0 {
+        return;
+    }
+    let radix: u32 = data[0].into();
+    let data = &data[1..];
+    if radix < 2 || radix > 36 {
+        return;
+    }
+    // parse the input
+    let result = btoi::btoi_radix::<u128>(data, radix);
+    // compare the resut to the stdlib implementation
+    if let Ok(string) = std::str::from_utf8(data) {
+        // std cannot handle "-0" in an unsigned type while btoi can
+        if string.starts_with("-0") {
+            return;
+        }
+        let std_result = u128::from_str_radix(string, radix);
+        match (result, std_result) {
+            (Ok(ours), Ok(std)) => assert_eq!(ours, std),
+            (Err(_), Err(_)) => (), // both failed, nothing to do
+            (ours, std) => panic!("Parsing result mismatch! Ours: {ours:?}, std: {std:?}"),
+        }
+    }
+});

--- a/fuzz/fuzz_targets/verify_u64.rs
+++ b/fuzz/fuzz_targets/verify_u64.rs
@@ -1,0 +1,31 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::str::FromStr;
+
+fuzz_target!(|data: &[u8]| {
+    // choose a random radix
+    if data.len() == 0 {
+        return;
+    }
+    let radix: u32 = data[0].into();
+    let data = &data[1..];
+    if radix < 2 || radix > 36 {
+        return;
+    }
+    // parse the input
+    let result = btoi::btoi_radix::<u64>(data, radix);
+    // compare the resut to the stdlib implementation
+    if let Ok(string) = std::str::from_utf8(data) {
+        // std cannot handle "-0" in an unsigned type while btoi can
+        if string.starts_with("-0") {
+            return;
+        }
+        let std_result = u64::from_str_radix(string, radix);
+        match (result, std_result) {
+            (Ok(ours), Ok(std)) => assert_eq!(ours, std),
+            (Err(_), Err(_)) => (), // both failed, nothing to do
+            (ours, std) => panic!("Parsing result mismatch! Ours: {ours:?}, std: {std:?}"),
+        }
+    }
+});

--- a/fuzz/fuzz_targets/verify_u64.rs
+++ b/fuzz/fuzz_targets/verify_u64.rs
@@ -1,7 +1,6 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use std::str::FromStr;
 
 fuzz_target!(|data: &[u8]| {
     // choose a random radix


### PR DESCRIPTION
Adds fuzz targets that verify that the result of `btoi` matches that of the standard library parser.

No issues found :+1: 