### PR TITLE
gate unit tests on the feature it needs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,43 +600,53 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "std")]
     use std::str;
 
     use super::*;
 
     quickcheck! {
+        #[cfg(feature = "std")]
         fn btou_identity(n: u32) -> bool {
             Ok(n) == btou(n.to_string().as_bytes())
         }
 
+        #[cfg(feature = "std")]
         fn btou_binary_identity(n: u64) -> bool {
             Ok(n) == btou_radix(format!("{:b}", n).as_bytes(), 2)
         }
 
+        #[cfg(feature = "std")]
         fn btou_octal_identity(n: u64) -> bool {
             Ok(n) == btou_radix(format!("{:o}", n).as_bytes(), 8)
         }
 
+        #[cfg(feature = "std")]
         fn btou_lower_hex_identity(n: u64) -> bool {
             Ok(n) == btou_radix(format!("{:x}", n).as_bytes(), 16)
         }
 
+        #[cfg(feature = "std")]
         fn btou_upper_hex_identity(n: u64) -> bool {
             Ok(n) == btou_radix(format!("{:X}", n).as_bytes(), 16)
         }
 
+        #[cfg(feature = "std")]
         fn btoi_identity(n: i32) -> bool {
             Ok(n) == btoi(n.to_string().as_bytes())
         }
 
+        #[cfg(feature = "std")]
         fn btou_saturating_identity(n: u32) -> bool {
             Ok(n) == btou_saturating(n.to_string().as_bytes())
         }
 
+        #[cfg(feature = "std")]
         fn btoi_saturating_identity(n: i32) -> bool {
             Ok(n) == btoi_saturating(n.to_string().as_bytes())
         }
 
+        #[cfg(feature = "std")]
         fn btoi_radix_std(bytes: Vec<u8>, radix: u32) -> bool {
             let radix = radix % 35 + 2; // panic unless 2 <= radix <= 36
             str::from_utf8(&bytes).ok().and_then(|src| i32::from_str_radix(src, radix).ok()) ==


### PR DESCRIPTION
This enables the test suite to be run with the --no-default-feature option.

Without this patch:

```
$ cargo test --no-default-features
   Compiling btoi v0.4.3 (/home/capitol/project/rust-btoi)
error[E0432]: unresolved import `std`
   --> src/lib.rs:603:9
    |
603 |     use std::str;
    |         ^^^ maybe a missing crate `std`?
    |
    = help: consider adding `extern crate std` to use the `std` crate

error: cannot find macro `format` in this scope
   --> src/lib.rs:625:33
    |
625 |             Ok(n) == btou_radix(format!("{:X}", n).as_bytes(), 16)
    |                                 ^^^^^^

error: cannot find macro `format` in this scope
   --> src/lib.rs:621:33
    |
621 |             Ok(n) == btou_radix(format!("{:x}", n).as_bytes(), 16)
    |                                 ^^^^^^

error: cannot find macro `format` in this scope
   --> src/lib.rs:617:33
    |
617 |             Ok(n) == btou_radix(format!("{:o}", n).as_bytes(), 8)
    |                                 ^^^^^^

error: cannot find macro `format` in this scope
   --> src/lib.rs:613:33
    |
613 |             Ok(n) == btou_radix(format!("{:b}", n).as_bytes(), 2)
    |                                 ^^^^^^

error[E0412]: cannot find type `Vec` in this scope
   --> src/lib.rs:640:34
    |
640 |         fn btoi_radix_std(bytes: Vec<u8>, radix: u32) -> bool {
    |                                  ^^^ not found in this scope

error[E0599]: no method named `to_string` found for type `u32` in the current scope
   --> src/lib.rs:609:29
    |
609 |             Ok(n) == btou(n.to_string().as_bytes())
    |                             ^^^^^^^^^ method not found in `u32`
   --> /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/alloc/src/string.rs:2503:8
    |
    = note: the method is available for `u32` here
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
603 +     use alloc::string::ToString;
    |

error[E0599]: no method named `to_string` found for type `i32` in the current scope
   --> src/lib.rs:629:29
    |
629 |             Ok(n) == btoi(n.to_string().as_bytes())
    |                             ^^^^^^^^^ method not found in `i32`
   --> /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/alloc/src/string.rs:2503:8
    |
    = note: the method is available for `i32` here
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
603 +     use alloc::string::ToString;
    |

error[E0599]: no method named `to_string` found for type `u32` in the current scope
   --> src/lib.rs:633:40
    |
633 |             Ok(n) == btou_saturating(n.to_string().as_bytes())
    |                                        ^^^^^^^^^ method not found in `u32`
   --> /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/alloc/src/string.rs:2503:8
    |
    = note: the method is available for `u32` here
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
603 +     use alloc::string::ToString;
    |

error[E0599]: no method named `to_string` found for type `i32` in the current scope
   --> src/lib.rs:637:40
    |
637 |             Ok(n) == btoi_saturating(n.to_string().as_bytes())
    |                                        ^^^^^^^^^ method not found in `i32`
   --> /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/alloc/src/string.rs:2503:8
    |
    = note: the method is available for `i32` here
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
603 +     use alloc::string::ToString;
    |

Some errors have detailed explanations: E0412, E0432, E0599.
For more information about an error, try `rustc --explain E0412`.
error: could not compile `btoi` (lib test) due to 10 previous errors
```